### PR TITLE
Fix docker-compose api ports

### DIFF
--- a/server/Publications/docker-compose.yml
+++ b/server/Publications/docker-compose.yml
@@ -8,8 +8,8 @@ services:
       dockerfile: Publications.API/Dockerfile
     restart: on-failure
     ports:
-      - "80:8080"
-      - "443:8081"
+      - "8080:8080"
+      - "8081:8081"
     depends_on:
       redis:
         condition: service_healthy


### PR DESCRIPTION
### Fix docker-compose api ports
- Changed porsts from "80" "443" to "8080" "8081" (because encountered an error when tried to `docker-compose up` on ec2 instance: Error response from daemon: driver failed programming external connectivity on endpoint publications.api (81a1f4eb22c000fa562dc14fafc8e282cf6a92045fbcea582ac7f6fdf11418b2): Error starting userland proxy: listen tcp4 0.0.0.0:443: bind: address already in use)